### PR TITLE
Adds 'staged' owner invoker instructions to reduce TX size

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,6 +77,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1643087856,
+        "narHash": "sha256-EreC7gP/T566PDRZjqNoTvByTyvABEpJpWFtyNUDS0Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8bd55a6a5ab05942af769c2aa2494044bff7f625",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -87,9 +103,7 @@
     "rust-overlay": {
       "inputs": {
         "flake-utils": "flake-utils_3",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1638325128,

--- a/programs/smart-wallet/src/lib.rs
+++ b/programs/smart-wallet/src/lib.rs
@@ -560,8 +560,10 @@ pub struct OwnerInvokeStagedInstruction<'info> {
     /// The [SmartWallet].
     pub smart_wallet: Account<'info, SmartWallet>,
     /// An owner of the [SmartWallet].
+    #[account(mut)]
     pub owner: Signer<'info>,
     /// The staged TX instruction.
+    #[account(mut, close = owner)]
     pub staged_tx_instruction: Account<'info, StagedTXInstruction>,
 }
 

--- a/programs/smart-wallet/src/lib.rs
+++ b/programs/smart-wallet/src/lib.rs
@@ -345,6 +345,59 @@ pub mod smart_wallet {
 
         Ok(())
     }
+
+    /// Creates a [StagedTXInstruction].
+    ///
+    /// A [StagedTXInstruction] may be used to minimize the instruction data when executing
+    /// an owner-invoked instruction.
+    #[access_control(ctx.accounts.validate())]
+    pub fn create_staged_tx_instruction(
+        ctx: Context<CreateStagedTXInstruction>,
+        _bump: u8,
+        index: u64,
+        owner_invoker_bump: u8,
+        ix: TXInstruction,
+    ) -> ProgramResult {
+        let staged = &mut ctx.accounts.staged_tx_instruction;
+
+        staged.smart_wallet = ctx.accounts.smart_wallet.key();
+        staged.index = index;
+        staged.owner_invoker_bump = owner_invoker_bump;
+
+        staged.owner = ctx.accounts.owner.key();
+        staged.owner_set_seqno = ctx.accounts.smart_wallet.owner_set_seqno;
+
+        staged.ix = ix;
+        Ok(())
+    }
+
+    /// Invokes an owner-invoker instruction as defined
+    /// in a PDA created in [create_staged_tx_instruction].
+    ///
+    /// This is useful for when the instruction is too large to fit in a single
+    /// transaction.
+    #[access_control(ctx.accounts.validate())]
+    pub fn owner_invoke_staged_instruction(
+        ctx: Context<OwnerInvokeStagedInstruction>,
+    ) -> ProgramResult {
+        let staged_tx_instruction = &ctx.accounts.staged_tx_instruction;
+
+        // Execute the transaction signed by the smart_wallet.
+        let invoker_seeds: &[&[&[u8]]] = &[&[
+            b"GokiSmartWalletOwnerInvoker" as &[u8],
+            &staged_tx_instruction.smart_wallet.to_bytes(),
+            &staged_tx_instruction.index.to_le_bytes(),
+            &[staged_tx_instruction.owner_invoker_bump],
+        ]];
+
+        solana_program::program::invoke_signed(
+            &(&ctx.accounts.staged_tx_instruction.ix).into(),
+            ctx.remaining_accounts,
+            invoker_seeds,
+        )?;
+
+        Ok(())
+    }
 }
 
 /// Accounts for [smart_wallet::create_smart_wallet].
@@ -464,6 +517,52 @@ pub struct CreateSubaccountInfo<'info> {
     pub payer: Signer<'info>,
     /// The [System] program.
     pub system_program: Program<'info, System>,
+}
+
+/// Accounts for [smart_wallet::create_staged_tx_instruction].
+#[derive(Accounts)]
+#[instruction(bump: u8)]
+pub struct CreateStagedTXInstruction<'info> {
+    /// The [SmartWallet].
+    pub smart_wallet: Account<'info, SmartWallet>,
+
+    /// The [SmartWallet] owner which will execute the instruction
+    /// and may receive the rent refund.
+    pub owner: Signer<'info>,
+
+    /// Random keypair used to create the [StagedTXInstruction].
+    pub base: Signer<'info>,
+
+    /// The [SubaccountInfo] to create.
+    #[account(
+        init,
+        seeds = [
+            b"GokiStagedTXInstruction".as_ref(),
+            smart_wallet.key().to_bytes().as_ref(),
+            owner.key().to_bytes().as_ref(),
+            base.key().to_bytes().as_ref()
+        ],
+        bump = bump,
+        payer = payer
+    )]
+    pub staged_tx_instruction: Account<'info, StagedTXInstruction>,
+
+    /// Payer to create the [StagedTXInstruction].
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    /// The [System] program.
+    pub system_program: Program<'info, System>,
+}
+
+/// Accounts for [smart_wallet::owner_invoke_staged_instruction].
+#[derive(Accounts)]
+pub struct OwnerInvokeStagedInstruction<'info> {
+    /// The [SmartWallet].
+    pub smart_wallet: Account<'info, SmartWallet>,
+    /// An owner of the [SmartWallet].
+    pub owner: Signer<'info>,
+    /// The staged TX instruction.
+    pub staged_tx_instruction: Account<'info, StagedTXInstruction>,
 }
 
 fn do_execute_transaction(ctx: Context<ExecuteTransaction>, seeds: &[&[&[u8]]]) -> ProgramResult {

--- a/programs/smart-wallet/src/state.rs
+++ b/programs/smart-wallet/src/state.rs
@@ -160,3 +160,25 @@ pub struct SubaccountInfo {
     /// Index of the sub-account.
     pub index: u64,
 }
+
+/// An account which holds the data of a single [TXInstruction].
+/// Creating this allows an owner-invoker to execute a transaction
+/// with a minimal transaction size.
+#[account]
+#[derive(Default, Debug, PartialEq)]
+pub struct StagedTXInstruction {
+    /// The [SmartWallet] to execute this on.
+    pub smart_wallet: Pubkey,
+    /// The owner-invoker index.
+    pub index: u64,
+    /// Bump seed of the owner-invoker.
+    pub owner_invoker_bump: u8,
+
+    /// The owner which will execute the instruction.
+    pub owner: Pubkey,
+    /// Owner set sequence number.
+    pub owner_set_seqno: u32,
+
+    /// The instruction to execute.
+    pub ix: TXInstruction,
+}

--- a/programs/smart-wallet/src/validators.rs
+++ b/programs/smart-wallet/src/validators.rs
@@ -98,3 +98,27 @@ impl<'info> Validate<'info> for CreateSubaccountInfo<'info> {
         Ok(())
     }
 }
+
+impl<'info> Validate<'info> for CreateStagedTXInstruction<'info> {
+    fn validate(&self) -> ProgramResult {
+        // validate the owner
+        self.smart_wallet.owner_index(self.owner.key())?;
+        Ok(())
+    }
+}
+
+impl<'info> Validate<'info> for OwnerInvokeStagedInstruction<'info> {
+    fn validate(&self) -> ProgramResult {
+        // ensure that the owner set is still fresh.
+        invariant!(
+            self.smart_wallet.owner_set_seqno == self.staged_tx_instruction.owner_set_seqno,
+            OwnerSetChanged
+        );
+
+        // check to see that this account is authorized to execute
+        // this transaction.
+        assert_keys_eq!(self.smart_wallet, self.staged_tx_instruction.smart_wallet);
+        assert_keys_eq!(self.owner, self.staged_tx_instruction.owner);
+        Ok(())
+    }
+}

--- a/tests/smartWallet.spec.ts
+++ b/tests/smartWallet.spec.ts
@@ -575,5 +575,95 @@ describe("smartWallet", () => {
       expect(info2.smartWallet).to.eqAddress(smartWalletWrapper.key);
       expect(info2.subaccountType).to.deep.eq({ ownerInvoker: {} });
     });
+
+    it("invoke large TX (v2)", async () => {
+      const index = 5;
+      const [invokerKey, invokerBump] =
+        await smartWalletWrapper.findOwnerInvokerAddress(index);
+
+      await new PendingTransaction(
+        provider.connection,
+        await provider.connection.requestAirdrop(invokerKey, LAMPORTS_PER_SOL)
+      ).wait();
+
+      const instructionToExecute = SystemProgram.transfer({
+        fromPubkey: invokerKey,
+        toPubkey: provider.wallet.publicKey,
+        lamports: LAMPORTS_PER_SOL,
+      });
+
+      const ix = sdk.programs.SmartWallet.instruction.ownerInvokeInstructionV2(
+        new BN(index),
+        invokerBump,
+        invokerKey,
+        instructionToExecute.data,
+        {
+          accounts: {
+            smartWallet: smartWalletWrapper.key,
+            owner: ownerA.publicKey,
+          },
+          remainingAccounts: [
+            {
+              pubkey: instructionToExecute.programId,
+              isSigner: false,
+              isWritable: false,
+            },
+            ...instructionToExecute.keys.map((k) => {
+              if (k.isSigner && invokerKey.equals(k.pubkey)) {
+                return {
+                  ...k,
+                  isSigner: false,
+                };
+              }
+              return k;
+            }),
+            /// Add 24 dummy keys
+            ...new Array(24).fill(null).map(() => ({
+              pubkey: Keypair.generate().publicKey,
+              isSigner: false,
+              isWritable: false,
+            })),
+          ],
+        }
+      );
+      const tx = new TransactionEnvelope(
+        smartWalletWrapper.provider,
+        [ix],
+        [ownerA]
+      );
+      await expectTX(tx, "transfer lamports to smart wallet").to.be.fulfilled;
+
+      await expectTX(
+        await sdk.createSubaccountInfo({
+          smartWallet: invokerKey,
+          index,
+          type: "ownerInvoker",
+        }),
+        "create wrong subaccount info"
+      ).to.be.fulfilled;
+
+      const [infoKey] = await findSubaccountInfoAddress(invokerKey);
+      const info =
+        await sdk.programs.SmartWallet.account.subaccountInfo.fetchNullable(
+          infoKey
+        );
+      expect(info).to.be.null;
+
+      await expectTX(
+        await sdk.createSubaccountInfo({
+          smartWallet: smartWalletWrapper.key,
+          index,
+          type: "ownerInvoker",
+        }),
+        "create subaccount info"
+      ).to.be.fulfilled;
+
+      const info2 = await sdk.programs.SmartWallet.account.subaccountInfo.fetch(
+        infoKey
+      );
+      expect(info2.index).to.bignumber.eq(index.toString());
+      expect(info2.smartWallet).to.eqAddress(smartWalletWrapper.key);
+      expect(info2.subaccountType).to.deep.eq({ ownerInvoker: {} });
+    });
   });
 });


### PR DESCRIPTION
The TX size of `owner_invoke_instruction` can be very large, and it duplicates accounts.

This separates owner invocation into two instructions:
- `create_staged_tx_instruction`, which writes the desired instruction to a PDA
- `owner_invoke_staged_instruction`, which invokes the staged instruction and closes its account.

Transaction size becomes significantly smaller, since no data must be passed in.